### PR TITLE
Support for percent sign in the protocol

### DIFF
--- a/docs/businterface.html
+++ b/docs/businterface.html
@@ -69,7 +69,7 @@ class MyInterface : StreamBusInterface
     bool <a href="#lock">lockRequest</a>(unsigned long lockTimeout_ms);
     bool <a href="#lock">unlock</a>();
     bool <a href="#write">writeRequest</a>(const void* output, size_t size, unsigned long writeTimeout_ms);
-    bool <a href="#read">readRequest</a>(unsigned long replyTimeout_ms, unsigned long readTimeout_ms, long expectedLength, bool async);
+    bool <a href="#read">readRequest</a>(unsigned long replyTimeout_ms, unsigned long readTimeout_ms, size_t expectedLength, bool async);
     bool <a href="#read">supportsAsyncRead</a>();
     bool <a href="#event">supportsEvent</a>();
     bool <a href="#event">acceptEvent</a>(unsigned long mask, unsigned long timeout_ms);
@@ -118,7 +118,7 @@ bool <a href="#write">writeRequest</a>(const&nbsp;void*&nbsp;output,
 <div class="indent"><code>
 bool <a href="#read">readRequest</a>(unsigned&nbsp;long&nbsp;replyTimeout_ms,
     unsigned&nbsp;long&nbsp;readTimeout_ms,
-    long&nbsp;expectedLength, bool&nbsp;async);
+    size_t&nbsp;expectedLength, bool&nbsp;async);
 </code></div>
 <div class="indent"><code>
 bool <a href="#read">supportsAsyncRead</a>();
@@ -460,7 +460,7 @@ The client may request more I/O or call <code>unlock()</code> after
 <div class="indent"><code>
 bool readRequest(unsigned&nbsp;long&nbsp;replyTimeout_ms,
     unsigned&nbsp;long&nbsp;readTimeout_ms,
-    long&nbsp;expectedLength, bool&nbsp;async);
+    size_t&nbsp;expectedLength, bool&nbsp;async);
 </code></div>
 <div class="indent"><code>
 ssize_t readCallback(IoStatus&nbsp;status,

--- a/docs/formats.html
+++ b/docs/formats.html
@@ -38,6 +38,18 @@ A format converter consists of
 </ul>
 
 <p>
+An exception is <code>%%</code> sequence which describes a single
+% (percent) sign in the protocol. It doesn't take any flags. It's implemented
+as a simple pseudo converter and can be used in conjuction with other converters.
+</p>
+
+<p>
+The flags <code>*# +0-</code> work like in the C functions
+<em>printf()</em> and <em>scanf()</em>.
+The flags <code>?</code>, <code>=</code> and <code>!</code> are extensions.
+</p>
+
+<p>
 The flags <code>*# +0-</code> work like in the C functions
 <em>printf()</em> and <em>scanf()</em>.
 The flags <code>?</code>, <code>=</code> and <code>!</code> are extensions.
@@ -117,6 +129,10 @@ This feature has been added by Klemen Vodopivec, SNS.
  <tr>
   <td><code>in "%=.3f";</code></td>
   <td>Assure that the input is equal to the current value formatted as a float with precision 3</td>
+ </tr>
+ <tr>
+  <td><code>in "%d%%";</code></td>
+  <td>Read an integer value followed by a % sign</td>
  </tr>
 </table>
 

--- a/src/StreamFormatConverter.cc
+++ b/src/StreamFormatConverter.cc
@@ -739,3 +739,44 @@ scanString(const StreamFormat& fmt, const char* input,
 }
 
 RegisterConverter (StdCharsetConverter, "[");
+
+// Standard Percent Converter for '%'
+
+class StdPercentConverter : public StreamFormatConverter
+{
+    int parse(const StreamFormat&, StreamBuffer&, const char*&, bool);
+    bool printPseudo(const StreamFormat&, StreamBuffer&);
+    ssize_t scanPseudo(const StreamFormat&, StreamBuffer&, size_t& cursor);
+};
+
+int StdPercentConverter::
+parse(const StreamFormat& fmt, StreamBuffer& info,
+    const char*& source, bool scanFormat)
+{
+    if (fmt.flags != 0)
+    {
+        error("Use of modifiers "
+              "not allowed with %%%% conversion\n");
+        return false;
+    }
+    return pseudo_format;
+}
+
+bool StdPercentConverter::
+printPseudo(const StreamFormat& fmt, StreamBuffer& output)
+{
+    output.append("%");
+    return true;
+}
+
+ssize_t StdPercentConverter::
+scanPseudo(const StreamFormat& fmt, StreamBuffer& input, size_t& cursor)
+{
+    ssize_t consumed = 0;
+    if (cursor < input.length() && input[cursor] == '%') {
+        consumed = 1;
+    }
+    return consumed;
+}
+
+RegisterConverter (StdPercentConverter, "%");


### PR DESCRIPTION
One of my hobby devices send humidity with % sign at the end. I added a pseudo converter to support that.

Second commit is a small fix to the documentation. While writing a new bus interface for the hobby device, I only found this thanks to using C++11 override feature. As I was mostly following documentation to write my code (and not the header files), this speaks to the quality of documentation. Hopefully this patch will save somebody else a bit of time.