### PR TITLE
Controlling the time to print messages on the IOC shell with a message engine

### DIFF
--- a/src/AsynDriverInterface.cc
+++ b/src/AsynDriverInterface.cc
@@ -766,13 +766,13 @@ writeHandler()
         case asynError:
             if (!connected)
             {
-                error("%s: device %s disconnected\n",
+                error(true, CAT_ASYN_WRITE, "%s: device %s disconnected\n",
                     clientName(), name());
                 disconnectCallback();
             }
             else
             {
-                error("%s: asynError in write: %s\n",
+                error(true, CAT_ASYN_WRITE, "%s: asynError in write: %s\n",
                     clientName(), pasynUser->errorMessage);
                 writeCallback(StreamIoFault);
             }
@@ -784,7 +784,7 @@ writeHandler()
             disconnectCallback();
             return;
         case asynDisabled:
-            error("%s: asynDisabled in write: %s\n",
+            error(true, CAT_ASYN_WRITE, "%s: asynDisabled in write: %s\n",
                 clientName(), pasynUser->errorMessage);
             writeCallback(StreamIoFault);
             return;
@@ -1085,26 +1085,26 @@ readHandler()
                 break;
             case asynError:
                 if (!connected) {
-                    error("%s: device %s disconnected\n",
+                    error(true, CAT_ASYN_READ,"%s: device %s disconnected\n",
                         clientName(), name());
                         disconnectCallback();
                 }
                 else
                 {
-                    error("%s: asynError in read: %s\n",
+                    error(true, CAT_ASYN_READ,"%s: asynError in read: %s\n",
                         clientName(), pasynUser->errorMessage);
                     readCallback(StreamIoFault, buffer, received);
                 }
                 break;
 #ifdef ASYN_VERSION // asyn >= 4.14
             case asynDisconnected:
-                error("%s: asynDisconnected in read: %s\n",
+                error(true, CAT_ASYN_READ,"%s: asynDisconnected in read: %s\n",
                     clientName(), pasynUser->errorMessage);
                 connected = false;
                 disconnectCallback();
                 return;
             case asynDisabled:
-                error("%s: asynDisabled in read: %s\n",
+                error(true, CAT_ASYN_READ, "%s: asynDisabled in read: %s\n",
                     clientName(), pasynUser->errorMessage);
                 readCallback(StreamIoFault);
                 return;

--- a/src/CONFIG_STREAM
+++ b/src/CONFIG_STREAM
@@ -93,3 +93,4 @@ STREAM_SRCS += StreamFormatConverter.cc
 STREAM_SRCS += StreamCore.cc
 STREAM_SRCS += StreamBusInterface.cc
 STREAM_SRCS += StreamEpics.cc
+STREAM_SRCS += messageEngine.cc

--- a/src/StreamCore.cc
+++ b/src/StreamCore.cc
@@ -685,10 +685,10 @@ normal_format:
                 {
                     StreamBuffer formatstr(formatstring, formatstringlen);
                     if (fieldAddress)
-                        error("%s: Cannot format field '%s' with '%%%s'\n",
+                        error(true, CAT_PROTO_FORMAT, "%s: Cannot format field '%s' with '%%%s'\n",
                             name(), fieldName, formatstr.expand()());
                     else
-                        error("%s: Cannot format value with '%%%s'\n",
+                        error(true, CAT_PROTO_FORMAT, "%s: Cannot format value with '%%%s'\n",
                             name(), formatstr.expand()());
                     return false;
                 }
@@ -742,7 +742,7 @@ printValue(const StreamFormat& fmt, long value)
 {
     if (fmt.type != unsigned_format && fmt.type != signed_format && fmt.type != enum_format)
     {
-        error("%s: printValue(long) called with %%%c format\n",
+        error(true, CAT_PROTO_FORMAT, "%s: printValue(long) called with %%%c format\n",
             name(), fmt.conv);
         return false;
     }
@@ -750,7 +750,7 @@ printValue(const StreamFormat& fmt, long value)
     if (!StreamFormatConverter::find(fmt.conv)->
         printLong(fmt, outputLine, value))
     {
-        error("%s: Formatting value %li failed\n",
+        error(true, CAT_PROTO_FORMAT, "%s: Formatting value %li failed\n",
             name(), value);
         return false;
     }
@@ -764,7 +764,7 @@ printValue(const StreamFormat& fmt, double value)
 {
     if (fmt.type != double_format)
     {
-        error("%s: printValue(double) called with %%%c format\n",
+        error(true, CAT_PROTO_FORMAT, "%s: printValue(double) called with %%%c format\n",
             name(), fmt.conv);
         return false;
     }
@@ -772,7 +772,7 @@ printValue(const StreamFormat& fmt, double value)
     if (!StreamFormatConverter::find(fmt.conv)->
         printDouble(fmt, outputLine, value))
     {
-        error("%s: Formatting value %#g failed\n",
+        error(true, CAT_PROTO_FORMAT, "%s: Formatting value %#g failed\n",
             name(), value);
         return false;
     }
@@ -786,7 +786,7 @@ printValue(const StreamFormat& fmt, char* value)
 {
     if (fmt.type != string_format)
     {
-        error("%s: printValue(char*) called with %%%c format\n",
+        error(true, CAT_PROTO_FORMAT, "%s: printValue(char*) called with %%%c format\n",
             name(), fmt.conv);
         return false;
     }
@@ -795,7 +795,7 @@ printValue(const StreamFormat& fmt, char* value)
         printString(fmt, outputLine, value))
     {
         StreamBuffer buffer(value);
-        error("%s: Formatting value \"%s\" failed\n",
+        error(true, CAT_PROTO_FORMAT, "%s: Formatting value \"%s\" failed\n",
             name(), buffer.expand()());
         return false;
     }
@@ -1094,7 +1094,7 @@ readCallback(StreamIoStatus status,
         }
         else
         {
-            error("%s: Timeout after reading %" Z "d byte%s \"%s%s\"\n",
+            error(true, CAT_READ_TIMEOUT, "%s: Timeout after reading %" Z "d byte%s \"%s%s\"\n",
                 name(), end, end==1 ? "" : "s", end > 20 ? "..." : "",
                 inputBuffer.expand(-20)());
         }
@@ -1234,7 +1234,7 @@ normal_format:
                         {
                             if (!(flags & AsyncMode) && onMismatch[0] != in)
                             {
-                                error("%s: Input \"%s%s\" does not match format \"%%%s\"\n",
+                                error(true, CAT_PROTO_FORMAT, "%s: Input \"%s%s\" does not match format \"%%%s\"\n",
                                     name(), inputLine.expand(consumedInput, 20)(),
                                     inputLine.length()-consumedInput > 20 ? "..." : "",
                                     formatstring());
@@ -1252,10 +1252,10 @@ normal_format:
                     if (!formatValue(fmt, fieldAddress ? fieldAddress() : NULL))
                     {
                         if (fieldAddress)
-                            error("%s: Cannot format variable \"%s\" with \"%%%s\"\n",
+                            error(true, CAT_PROTO_FORMAT, "%s: Cannot format variable \"%s\" with \"%%%s\"\n",
                                 name(), fieldName, formatstring());
                         else
-                            error("%s: Cannot format value with \"%%%s\"\n",
+                            error(true, CAT_PROTO_FORMAT, "%s: Cannot format value with \"%%%s\"\n",
                                 name(), formatstring());
                         return false;
                     }
@@ -1266,7 +1266,7 @@ normal_format:
                     {
                         if (!(flags & AsyncMode) && onMismatch[0] != in)
                         {
-                            error("%s: Input \"%s%s\" too short."
+                            error(true, CAT_PROTO_FORMAT, "%s: Input \"%s%s\" too short."
                                   " No match for format \"%%%s\" (\"%s\")\n",
                                 name(),
                                 inputLine.length() > 20 ? "..." : "",
@@ -1280,7 +1280,7 @@ normal_format:
                     {
                         if (!(flags & AsyncMode) && onMismatch[0] != in)
                         {
-                            error("%s: Input \"%s%s\" does not match format \"%%%s\" (\"%s\")\n",
+                            error(true, CAT_PROTO_FORMAT, "%s: Input \"%s%s\" does not match format \"%%%s\" (\"%s\")\n",
                                 name(), inputLine.expand(consumedInput, 20)(),
                                 inputLine.length()-consumedInput > 20 ? "..." : "",
                                 formatstring(),
@@ -1297,12 +1297,12 @@ normal_format:
                     if (!(flags & AsyncMode) && onMismatch[0] != in)
                     {
                         if (flags & ScanTried)
-                            error("%s: Input \"%s%s\" does not match format \"%%%s\"\n",
+                            error(true, CAT_PROTO_FORMAT, "%s: Input \"%s%s\" does not match format \"%%%s\"\n",
                                 name(), inputLine.expand(consumedInput, 20)(),
                                 inputLine.length()-consumedInput > 20 ? "..." : "",
                                 formatstring());
                         else
-                            error("%s: Format \"%%%s\" has data type %s which is not supported by \"%s\".\n",
+                            error(true, CAT_PROTO_FORMAT, "%s: Format \"%%%s\" has data type %s which is not supported by \"%s\".\n",
                                 name(), formatstring(), StreamFormatTypeStr[fmt.type], fieldAddress ? fieldName : name());
                     }
                     return false;
@@ -1329,11 +1329,11 @@ normal_format:
                     while (commandIndex[i] >= ' ') i++;
                     if (!(flags & AsyncMode) && onMismatch[0] != in)
                     {
-                        error("%s: Input \"%s%s\" too short.\n",
+                        error(true, CAT_PROTO_FORMAT, "%s: Input \"%s%s\" too short.\n",
                             name(),
                             inputLine.length() > 20 ? "..." : "",
                             inputLine.expand(-20)());
-                        error("No match for \"%s\"\n",
+                        error(true, CAT_PROTO_FORMAT, "No match for \"%s\"\n",
                             StreamBuffer(commandIndex-1,i+1).expand()());
                     }
                     return false;
@@ -1344,13 +1344,13 @@ normal_format:
                     {
                         int i = 0;
                         while (commandIndex[i] >= ' ') i++;
-                        error("%s: Input \"%s%s%s\"\n", 
+                        error(true, CAT_PROTO_FORMAT, "%s: Input \"%s%s%s\"\n", 
                             name(),
                             consumedInput > 20 ? "..." : "",
                             inputLine.expand(consumedInput > 20 ? consumedInput-20 : 0, 40)(),
                             inputLine.length() - consumedInput > 20 ? "..." : "");
 
-                        error("%s: mismatch after %" Z "d byte%s \"%s%s\"\n",
+                        error(true, CAT_PROTO_FORMAT, "%s: mismatch after %" Z "d byte%s \"%s%s\"\n",
                             name(),
                             consumedInput,
                             consumedInput==1 ? "" : "s",
@@ -1358,7 +1358,7 @@ normal_format:
                             inputLine.expand(consumedInput > 10 ? consumedInput-10 : 0,
                                 consumedInput > 10 ? 10 : consumedInput)());
                         
-                        error("%s: got \"%s%s\" where \"%s\" was expected\n",
+                        error(true, CAT_PROTO_FORMAT, "%s: got \"%s%s\" where \"%s\" was expected\n",
                             name(),
                             inputLine.expand(consumedInput, 10)(),
                             inputLine.length() - consumedInput > 10 ? "..." : "",
@@ -1374,18 +1374,18 @@ normal_format:
     {
         if (!(flags & AsyncMode) && onMismatch[0] != in)
         {
-            error("%s: %" Z "d byte%s surplus input \"%s%s\"\n",
+            error(true, CAT_PROTO_FORMAT, "%s: %" Z "d byte%s surplus input \"%s%s\"\n",
                 name(), surplus, surplus==1 ? "" : "s",
                 inputLine.expand(consumedInput, 20)(),
                 surplus > 20 ? "..." : "");
 
             if (consumedInput>20)
-                error("%s: after %" Z "d byte%s \"...%s\"\n",
+                error(true, CAT_PROTO_FORMAT, "%s: after %" Z "d byte%s \"...%s\"\n",
                     name(), consumedInput,
                     consumedInput==1 ? "" : "s",
                     inputLine.expand(consumedInput-20, 20)());
             else
-                error("%s: after %" Z "d byte%s: \"%s\"\n",
+                error(true, CAT_PROTO_FORMAT, "%s: after %" Z "d byte%s: \"%s\"\n",
                     name(), consumedInput,
                     consumedInput==1 ? "" : "s",
                     inputLine.expand(0, consumedInput)());
@@ -1449,7 +1449,7 @@ scanValue(const StreamFormat& fmt, long& value)
 {
     if (fmt.type != unsigned_format && fmt.type != signed_format && fmt.type != enum_format)
     {
-        error("%s: scanValue(long&) called with %%%c format\n",
+        error(true, CAT_PROTO_FORMAT, "%s: scanValue(long&) called with %%%c format\n",
             name(), fmt.conv);
         return -1;
     }
@@ -1481,7 +1481,7 @@ scanValue(const StreamFormat& fmt, double& value)
 {
     if (fmt.type != double_format)
     {
-        error("%s: scanValue(double&) called with %%%c format\n",
+        error(true, CAT_PROTO_FORMAT, "%s: scanValue(double&) called with %%%c format\n",
             name(), fmt.conv);
         return -1;
     }
@@ -1513,7 +1513,7 @@ scanValue(const StreamFormat& fmt, char* value, size_t& size)
 {
     if (fmt.type != string_format)
     {
-        error("%s: scanValue(char*) called with %%%c format\n",
+        error(true, CAT_PROTO_FORMAT, "%s: scanValue(char*) called with %%%c format\n",
             name(), fmt.conv);
         return -1;
     }
@@ -1596,7 +1596,7 @@ eventCallback(StreamIoStatus status)
     switch (status)
     {
         case StreamIoTimeout:
-            error("%s: No event from device\n", name());
+            error(true, CAT_IO_TIMEOUT, "%s: No event from device\n", name());
             finishProtocol(ReplyTimeout);
             return;
         case StreamIoSuccess:

--- a/src/StreamEpics.cc
+++ b/src/StreamEpics.cc
@@ -258,6 +258,21 @@ long streamSetLogfile(const char* filename)
     return OK;
 }
 
+extern "C" long streamMessageTimeout(int timeout)
+{
+    if (!pErrEngine)
+    {
+        // To avoid warning complaints from the compiler 
+        pthread_t thread_id = 0;
+        pErrEngine = createEngine(thread_id);
+        pErrEngine->setTimeout(timeout);
+    }
+
+    pErrEngine->setTimeout(timeout);
+
+    return OK;
+}
+
 #ifndef EPICS_3_13
 static const iocshArg streamReloadArg0 =
     { "recordname", iocshArgString };
@@ -295,11 +310,27 @@ void streamSetLogfileFunc (const iocshArgBuf *args)
     streamSetLogfile(args[0].sval);
 }
 
+// Setting a timeout for messages at the IOC Console will trigger the message
+// engine thread.
+static const iocshArg streamMessageTimeoutArg0 =
+    { "timeout (s)", iocshArgInt };
+static const iocshArg * const streamMessageTimeoutArgs[] =
+    { &streamMessageTimeoutArg0 };
+static const iocshFuncDef messageTimeoutDef =
+    { "streamMessageTimeout", 1, streamMessageTimeoutArgs };
+
+extern "C" void messageTimeoutFunc (const iocshArgBuf *args)
+{
+    streamMessageTimeout(args[0].ival);
+}
+
+
 static void streamRegistrar ()
 {
     iocshRegister(&streamReloadDef, streamReloadFunc);
     iocshRegister(&streamReportRecordDef, streamReportRecordFunc);
     iocshRegister(&streamSetLogfileDef, streamSetLogfileFunc);
+    iocshRegister(&messageTimeoutDef, messageTimeoutFunc);
     // make streamReload available for subroutine records
     registryFunctionAdd("streamReload",
         (REGISTRYFUNCTION)streamReloadSub);
@@ -308,7 +339,7 @@ static void streamRegistrar ()
 }
 
 extern "C" {
-epicsExportRegistrar(streamRegistrar);
+    epicsExportRegistrar(streamRegistrar);
 }
 
 

--- a/src/StreamEpics.cc
+++ b/src/StreamEpics.cc
@@ -266,8 +266,7 @@ extern "C" long streamMessageTimeout(int timeout)
     if (!pErrEngine)
     {
         // To avoid warning complaints from the compiler 
-        pthread_t thread_id = 0;
-        pErrEngine = createEngine(thread_id);
+        pErrEngine = createEngine();
         pErrEngine->setTimeout(timeout);
     }
 

--- a/src/StreamEpics.cc
+++ b/src/StreamEpics.cc
@@ -618,7 +618,7 @@ long streamReadWrite(dbCommon *record)
     if (!stream || stream->status == ERROR)
     {
         (void) recGblSetSevr(record, UDF_ALARM, INVALID_ALARM);
-        error("%s: Record not initialised correctly\n", record->name);
+        error(true, CAT_PROTO_FORMAT, "%s: Record not initialised correctly\n", record->name);
         return ERROR;
     }
     return stream->process() ? stream->convert : ERROR;

--- a/src/StreamError.cc
+++ b/src/StreamError.cc
@@ -153,7 +153,7 @@ void StreamVError(int line, const char* file,
         va_end(args2);
     }
 #endif
-    snprintf(buffer2, "%s%s ", ansiEscape(ANSI_RED_BOLD), timestamp);
+    snprintf(buffer2, sizeof(buffer2), "%s%s ", ansiEscape(ANSI_RED_BOLD), timestamp);
     if (file)
     {
         snprintf(buffer1, sizeof(buffer1), "%s%s line %d: ", buffer2, file, line);

--- a/src/StreamError.h
+++ b/src/StreamError.h
@@ -23,9 +23,13 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#include "messageEngine.h"
+
 #ifndef __GNUC__
 #define __attribute__(x)
 #endif
+
+extern StreamErrorEngine* pErrEngine;
 
 extern int streamDebug;
 extern int streamError;
@@ -34,15 +38,28 @@ extern void (*StreamPrintTimestampFunction)(char* buffer, size_t size);
 void StreamError(int line, const char* file, const char* fmt, ...)
 __attribute__((__format__(__printf__,3,4)));
 
-void StreamVError(int line, const char* file, const char* fmt, va_list args)
-__attribute__((__format__(__printf__,3,0)));
+void StreamVError(int line, const char* file,
+                  ErrorCategory category,
+                  const char* fmt, va_list args)
+__attribute__((__format__(__printf__,4,0)));
 
 void StreamError(const char* fmt, ...)
 __attribute__((__format__(__printf__,1,2)));
 
+// Need to place a useless bool parameter to avoid overload ambiguity
+void StreamError(bool useless, int line, const char* file,
+                 ErrorCategory category,
+                 const char* fmt, ...)
+__attribute__ ((format(printf,5,6)));
+
+// Need to place a useless bool parameter to avoid overload ambiguity
+void StreamError(bool useless, ErrorCategory category, 
+                 const char* fmt, ...)
+__attribute__ ((format(printf,3,4)));
+
 inline void StreamVError(const char* fmt, va_list args)
 {
-    StreamVError(0, NULL, fmt, args);
+    StreamVError(0, NULL, CAT_NONE, fmt, args); 
 }
 
 class StreamDebugClass

--- a/src/messageEngine.cc
+++ b/src/messageEngine.cc
@@ -1,0 +1,177 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <cstring>
+#include <new>
+#include <cstdlib>
+
+#include "messageEngine.h"
+
+StreamErrorEngine* createEngine(pthread_t thread_id)
+{
+    StreamErrorEngine* newEngine = new StreamErrorEngine;
+    pthread_create(&thread_id, NULL, engineJob, 
+                   reinterpret_cast<void *>(newEngine));
+    return newEngine;
+}
+
+void *engineJob(void* engineObj) 
+{
+    int iii; // loop index
+    int elapsedTime;
+
+    StreamErrorEngine* engine = reinterpret_cast<StreamErrorEngine*>(engineObj);
+    errorData_t* errData;
+    
+    while(1) 
+    {   
+        if (engine->mustStop())
+        {
+            // Time to finish the thread
+            pthread_exit(0);
+        }
+
+        // Loop through all error categories
+        for(iii=0; iii<TOTAL_CATEGORIES; ++iii) 
+        {
+            errData = engine->errorDataFrom(static_cast<ErrorCategory>(iii));
+ 
+            if (! errData)
+            {
+                continue;
+            }
+
+            // Lock access to error data
+            pthread_mutex_lock(&errData->mutex);
+            
+            // Timeout?
+            elapsedTime = difftime(time(NULL),
+                                   errData->lastPrintTime);
+            
+            if (elapsedTime >= engine->getTimeout()) 
+            {
+                if (errData->numberOfCalls != 0) 
+                {
+                    // Print error message
+                    fprintf(stderr, "Stream Device: this message was received %d times"
+                            " in the last %d seconds:\n", 
+                            errData->numberOfCalls, 
+                            elapsedTime);
+                    fprintf(stderr,
+                            errData->lastErrorMessage);
+                    // Restart number of calls
+                    errData->numberOfCalls = 0;
+                    // Reset last message time
+                    errData->lastPrintTime = time(NULL);
+                } // if # of calls != 0
+                else
+                {
+                    errData->waitingTimeout = false;
+                }
+            } // if timeout
+
+            // Release lock
+            pthread_mutex_unlock(&errData->mutex);
+
+        } // for
+
+        sleep(ENGINE_POLLING_TIME);
+    } // while(1)
+
+    return 0;
+}
+
+StreamErrorEngine::StreamErrorEngine()
+{
+    stopThread = false;
+
+    for (int iii=0; iii<TOTAL_CATEGORIES; ++iii)
+    {
+        categories[iii].waitingTimeout = 0;
+        categories[iii].lastPrintTime = time(NULL);
+        categories[iii].numberOfCalls = 0;
+        strcpy(categories[iii].lastErrorMessage, "\0");
+        pthread_mutex_init(&categories[iii].mutex, NULL);
+    }
+}
+
+StreamErrorEngine::~StreamErrorEngine()
+{
+    // Order message engine thread to stop
+    stopThread = true;
+
+    // Wait for thread to stop
+    pthread_join(thread_id, NULL);
+
+    // Cleanup
+    for (int iii=0; iii<TOTAL_CATEGORIES; ++iii)
+    {
+        pthread_mutex_destroy(&categories[iii].mutex);
+    }
+}
+
+void StreamErrorEngine::callError(ErrorCategory category, char* message)
+{
+    if (category < 0 || category > TOTAL_CATEGORIES)
+    {
+        return;
+    }
+    
+    // Using errData variable is easier to read than categories[category] 
+    errorData_t* errData = &categories[category];
+    
+    // Lock access to error data
+    pthread_mutex_lock(&errData->mutex);
+
+    // If it is waiting timeout, just increment the number of calls for that
+    // error category.
+    if (errData->waitingTimeout)
+    {
+        errData->numberOfCalls++;
+    }
+    else
+    // It is not waiting for timeout, what means that this is the first message
+    // since a long time ago.
+    {
+        // Print message right away
+        fprintf(stderr, message);
+        // Signal that now we are waiting for a timeout before printing another
+        // message
+        errData->waitingTimeout = true;
+        // Remember the error message to use later
+        strcpy(errData->lastErrorMessage, message);
+        // Starting time to detect a future timeout
+        errData->lastPrintTime = time(NULL);
+        // Restart message counter
+        errData->numberOfCalls = 0;
+    }
+    
+    // Release lock
+    pthread_mutex_unlock(&errData->mutex);
+}
+
+void StreamErrorEngine::setTimeout(int tmout)
+{
+    timeout = tmout;
+}
+
+int StreamErrorEngine::getTimeout()
+{
+    return timeout;
+}
+
+errorData_t* StreamErrorEngine::errorDataFrom(ErrorCategory category)
+{
+    if (category >= 0 && category <= TOTAL_CATEGORIES)
+    {
+        return &categories[category];
+    }
+    else
+    {
+        return NULL;
+    }
+}
+
+bool StreamErrorEngine::mustStop()
+{
+    return stopThread;
+}

--- a/src/messageEngine.h
+++ b/src/messageEngine.h
@@ -1,0 +1,54 @@
+#ifndef messageEngine_h
+#define messageEngine_h
+
+#include <string>
+#include <time.h>
+#include <pthread.h>
+
+struct errorData_t 
+{
+    bool waitingTimeout;
+    time_t lastPrintTime;
+    int numberOfCalls;
+    char lastErrorMessage[500];
+    pthread_mutex_t mutex;
+} ;
+
+// Polling time in seconds
+#define ENGINE_POLLING_TIME 1
+
+// Errors are grouped by categories. TOTAL_CATEGORIES does not count CAT_NONE.
+#define TOTAL_CATEGORIES 6
+enum ErrorCategory
+{
+    CAT_NONE = -1,
+    CAT_ASYN_CONNECTION,
+    CAT_ASYN_READ,
+    CAT_ASYN_WRITE,
+    CAT_READ_TIMEOUT,
+    CAT_IO_TIMEOUT,
+    CAT_PROTO_FORMAT
+};
+
+class StreamErrorEngine 
+{
+private:
+    struct errorData_t categories[TOTAL_CATEGORIES];
+    int timeout; // in seconds
+    pthread_t thread_id;
+    bool stopThread;
+public:
+    StreamErrorEngine();
+    ~StreamErrorEngine();
+    void setTimeout(int tmout);
+    int getTimeout();
+    errorData_t* errorDataFrom(ErrorCategory category); 
+    void callError(ErrorCategory category, char* message);
+    bool mustStop();
+};
+
+// Wrappers for C functions because we don't have C++11
+StreamErrorEngine* createEngine(pthread_t thread_id);
+void *engineJob(void* engineObj);
+
+#endif

--- a/src/messageEngine.h
+++ b/src/messageEngine.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <time.h>
-#include <pthread.h>
+#include <epicsMutex.h>
 
 struct errorData_t 
 {
@@ -11,7 +11,7 @@ struct errorData_t
     time_t lastPrintTime;
     int numberOfCalls;
     char lastErrorMessage[500];
-    pthread_mutex_t mutex;
+    epicsMutex* mutex;
 } ;
 
 // Polling time in seconds
@@ -30,12 +30,11 @@ enum ErrorCategory
     CAT_PROTO_FORMAT
 };
 
-class StreamErrorEngine 
+class StreamErrorEngine
 {
 private:
     struct errorData_t categories[TOTAL_CATEGORIES];
     int timeout; // in seconds
-    pthread_t thread_id;
     bool stopThread;
 public:
     StreamErrorEngine();
@@ -48,7 +47,7 @@ public:
 };
 
 // Wrappers for C functions because we don't have C++11
-StreamErrorEngine* createEngine(pthread_t thread_id);
+StreamErrorEngine* createEngine();
 void *engineJob(void* engineObj);
 
 #endif


### PR DESCRIPTION
The idea is to have a thread that controls when a message should be printed based on a configurable timeout. I tried to make the changes generic, not dependent on EPICS, but it was not fully accomplished. To activate the message engine, an IOC shell function must be used: streamMessageTimeout with the number of seconds of timeout.

The changes are fully compatible with the current version of Stream Device as, if the user doesn't call streamMessageTimeout, the behavior is still the same as before.

Instead of comparing strings, I decided to group the calls to the error macro in numeric categories. This would avoid a frenetic string comparison in the case of hundreds of messages per second being print, which could impact the performance of the message engine.

This is the data structure and the algorithm developed:

![Stream Device algorithm for error messages](https://user-images.githubusercontent.com/17479392/58737908-410b6e00-83b8-11e9-9e01-24e121880444.png)

These are the needed changes in StreamError.h and StreamError.cc.

![Original Algorithm](https://user-images.githubusercontent.com/17479392/58737946-71eba300-83b8-11e9-9e9d-ed5c8264e03f.png)
