### PR TITLE
remove error message in streamReadWrite

### DIFF
--- a/src/StreamEpics.cc
+++ b/src/StreamEpics.cc
@@ -587,7 +587,6 @@ long streamReadWrite(dbCommon *record)
     if (!stream || stream->status == ERROR)
     {
         (void) recGblSetSevr(record, UDF_ALARM, INVALID_ALARM);
-        error("%s: Record not initialised correctly\n", record->name);
         return ERROR;
     }
     return stream->process() ? stream->convert : ERROR;


### PR DESCRIPTION
If the record hasn't been initialized correctly, we don't want the console
to be spammed every time the record gets processed.