### PR TITLE
Added compatibility for using vsnprintf on VS2010 and lower

### DIFF
--- a/src/StreamBuffer.cc
+++ b/src/StreamBuffer.cc
@@ -306,6 +306,14 @@ print(const char* fmt, ...)
             return *this;
         }
         if (printed > -1) grow(len+printed);
+// Previous versions of VS return -1 on vsnprintf if the print is not possible.
+#if defined (_WIN32) && (_MSC_VER < 1700)
+        else if (printed == -1) {
+            va_start(va, fmt);
+            grow(len + _vscprintf(fmt, va));
+            va_end(va);
+        }
+#endif
         else grow(len);
     }
 }


### PR DESCRIPTION
Under earlier versions of visual studio (VS2010 and below) vsnprintf will return a -1 if there is not enough room to print. Later versions (and linux) will return the number of characters that would have been printed if there was room, which was then used in StreamBuffer to expand the buffer. This leads to an infinite loop on VS2010.

This change calls _vscprintf instead (for VS2010) to get the size required to expand the buffer.

I also thought about using `epicsVsnprintf` from EPICS base but as that hasn't already been used for the vxWorks compatibility I assume you don't want to add an EPICS dependency into `StreamBuffer`?