### PR TITLE
Remove HOST_OPT=NO

### DIFF
--- a/configure/CONFIG_APP
+++ b/configure/CONFIG_APP
@@ -24,4 +24,3 @@ endif
 
 # dbst based database optimization (default: NO)
 DB_OPT = NO
-HOST_OPT=NO


### PR DESCRIPTION
On Windows changing HOST_OPT changes the compiler flags, potentially resulting in the mixing of debug and release libraries in the final IOC