### PR TITLE
Handle 64 bit int format on record support

### DIFF
--- a/src/StreamEpics.cc
+++ b/src/StreamEpics.cc
@@ -905,6 +905,10 @@ print(format_t *format, va_list ap)
 {
     switch (format->type)
     {
+#ifdef DBR_INT64
+        case DBF_INT64:
+        case DBF_UINT64:
+#endif
         case DBF_ULONG:
         case DBF_LONG:
         case DBF_ENUM:
@@ -931,6 +935,10 @@ scan(format_t *format, void* value, size_t maxStringSize)
     currentValueLength = 0;
     switch (format->type)
     {
+#ifdef DBR_INT64
+        case DBF_INT64:
+        case DBF_UINT64:
+#endif
         case DBF_ULONG:
         case DBF_LONG:
         case DBF_ENUM:

--- a/src/devaaiStream.c
+++ b/src/devaaiStream.c
@@ -55,6 +55,10 @@ static long readData(dbCommon *record, format_t *format)
                 }
                 break;
             }
+#ifdef DBR_INT64
+            case DBF_INT64:
+            case DBF_UINT64:
+#endif
             case DBF_ULONG:
             case DBF_LONG:
             case DBF_ENUM:
@@ -206,6 +210,10 @@ static long writeData(dbCommon *record, format_t *format)
                     return ERROR;
                 break;
             }
+#ifdef DBR_INT64
+            case DBF_INT64:
+            case DBF_UINT64:
+#endif
             case DBF_ULONG:
             case DBF_LONG:
             case DBF_ENUM:

--- a/src/devaaoStream.c
+++ b/src/devaaoStream.c
@@ -56,6 +56,10 @@ static long readData(dbCommon *record, format_t *format)
                 }
                 break;
             }
+#ifdef DBR_INT64
+            case DBF_INT64:
+            case DBF_UINT64:
+#endif
             case DBF_ULONG:
             case DBF_LONG:
             case DBF_ENUM:
@@ -235,6 +239,10 @@ static long writeData(dbCommon *record, format_t *format)
                     return ERROR;
                 break;
             }
+#ifdef DBR_INT64
+            case DBF_INT64:
+            case DBF_UINT64:
+#endif
             case DBF_ULONG:
             case DBF_LONG:
             case DBF_ENUM:

--- a/src/devaiStream.c
+++ b/src/devaiStream.c
@@ -35,6 +35,10 @@ static long readData(dbCommon *record, format_t *format)
             if (streamScanf(record, format, &val) == ERROR) return ERROR;
             break;
         }
+#ifdef DBR_INT64
+        case DBF_INT64:
+        case DBF_UINT64:
+#endif
         case DBF_ULONG:
         case DBF_LONG:
         {

--- a/src/devaoStream.c
+++ b/src/devaoStream.c
@@ -38,6 +38,10 @@ static long readData(dbCommon *record, format_t *format)
             if (streamScanf(record, format, &val) == ERROR) return ERROR;
             break;
         }
+#ifdef DBR_INT64
+        case DBF_INT64:
+        case DBF_UINT64:
+#endif
         case DBF_ULONG:
         case DBF_LONG:
         {
@@ -45,7 +49,11 @@ static long readData(dbCommon *record, format_t *format)
             if (streamScanf(record, format, &rval) == ERROR) return ERROR;
             ao->rbv = rval;
             ao->rval = rval;
+#ifdef DBR_INT64
+            if (format->type == DBF_ULONG || format->type == DBF_UINT64)
+#else
             if (format->type == DBF_ULONG)
+#endif
                 val = (unsigned long)rval;
             else
                 val = rval;
@@ -119,6 +127,9 @@ static long writeData(dbCommon *record, format_t *format)
         {
             return streamPrintf(record, format, val);
         }
+#ifdef DBR_INT64
+        case DBF_UINT64:
+#endif
         case DBF_ULONG:
         {
             if (ao->linr == 0)
@@ -128,6 +139,9 @@ static long writeData(dbCommon *record, format_t *format)
             }
             return streamPrintf(record, format, (unsigned long)ao->rval);
         }
+#ifdef DBR_INT64
+        case DBF_INT64:
+#endif
         case DBF_LONG:
         {
             if (ao->linr == 0)

--- a/src/devbiStream.c
+++ b/src/devbiStream.c
@@ -30,6 +30,10 @@ static long readData(dbCommon *record, format_t *format)
 
     switch (format->type)
     {
+#ifdef DBR_INT64
+        case DBF_INT64:
+        case DBF_UINT64:
+#endif
         case DBF_ULONG:
         case DBF_LONG:
         {
@@ -70,6 +74,10 @@ static long writeData(dbCommon *record, format_t *format)
 
     switch (format->type)
     {
+#ifdef DBR_INT64
+        case DBF_INT64:
+        case DBF_UINT64:
+#endif
         case DBF_ULONG:
         case DBF_LONG:
         {

--- a/src/devboStream.c
+++ b/src/devboStream.c
@@ -31,6 +31,10 @@ static long readData(dbCommon *record, format_t *format)
 
     switch (format->type)
     {
+#ifdef DBR_INT64
+        case DBF_INT64:
+        case DBF_UINT64:
+#endif
         case DBF_ULONG:
         case DBF_LONG:
         {

--- a/src/devint64inStream.c
+++ b/src/devint64inStream.c
@@ -29,6 +29,8 @@ static long readData(dbCommon *record, format_t *format)
 
     switch (format->type)
     {
+        case DBF_INT64:
+        case DBF_UINT64:
         case DBF_ULONG:
         case DBF_LONG:
         case DBF_ENUM:
@@ -51,6 +53,8 @@ static long writeData(dbCommon *record, format_t *format)
 
     switch (format->type)
     {
+        case DBF_INT64:
+        case DBF_UINT64:
         case DBF_ULONG:
         case DBF_ENUM:
         case DBF_LONG:

--- a/src/devint64outStream.c
+++ b/src/devint64outStream.c
@@ -33,6 +33,8 @@ static long readData(dbCommon *record, format_t *format)
 
     switch (format->type)
     {
+        case DBF_INT64:
+        case DBF_UINT64:
         case DBF_ULONG:
         case DBF_LONG:
         case DBF_ENUM:
@@ -72,6 +74,8 @@ static long writeData(dbCommon *record, format_t *format)
 
     switch (format->type)
     {
+        case DBF_INT64:
+        case DBF_UINT64:
         case DBF_ULONG:
         case DBF_ENUM:
         case DBF_LONG:

--- a/src/devwaveformStream.c
+++ b/src/devwaveformStream.c
@@ -56,6 +56,10 @@ static long readData(dbCommon *record, format_t *format)
                 }
                 break;
             }
+#ifdef DBR_INT64
+            case DBF_INT64:
+            case DBF_UINT64:
+#endif
             case DBF_ULONG:
             case DBF_LONG:
             case DBF_ENUM:
@@ -207,6 +211,10 @@ static long writeData(dbCommon *record, format_t *format)
                     return ERROR;
                 break;
             }
+#ifdef DBR_INT64
+            case DBF_INT64:
+            case DBF_UINT64:
+#endif
             case DBF_LONG:
             case DBF_ULONG:
             case DBF_ENUM:


### PR DESCRIPTION
On systems that have INT64 and UINT64 enabled, the default signed and unsigned format types are promoted to 64 bits, so these types have to be included on the record support readData and writeData functions to avoid conversion errors.

This problem is probably lying around for some time, but it was only brought up after the bugfix 3eac2b804d279031adbdfb0ba436da7cbad59101 which actually allowed the DBF_UINT64 and DBF_INT64 related code to be executed.

Details on: https://epics.anl.gov/tech-talk/2020/msg00361.php