### PR TITLE
Link streamApp against seq and pv libs when SNCSEQ is defined

### DIFF
--- a/streamApp/Makefile
+++ b/streamApp/Makefile
@@ -68,6 +68,10 @@ PROD_LIBS += sscan
 endif
 endif
 
+ifneq ($(words $(SNCSEQ) $(SYNAPPS)), 0)
+PROD_LIBS += seq pv
+endif
+
 streamApp_DBD += stream.dbd
 
 ifdef PCRE


### PR DESCRIPTION
Compiling streamDevice with the latest asyn (https://github.com/epics-modules/asyn/commit/332e56ab5c6a24e39f9b49b06481841dc42900f5) gives out the following error when SNCSEQ module is used:

```
/usr/bin/g++ -o streamApp -Wl,-Bstatic -L/data/bdee/devel/wavepro_dev1/streamdevice/lib/linux-x86_64 -L/data/bdee/devel/wavepro_dev1/asyn/lib/linux-x86_64 -L/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64 -L/data/bdee/devel/wavepro_dev1/epics-base/lib/linux-x86_64 -L/data/bdee/devel/wavepro_dev1/sscan/lib/linux-x86_64 -Wl,-rpath,/data/bdee/devel/wavepro_dev1/streamdevice/lib/linux-x86_64 -Wl,-rpath,/data/bdee/devel/wavepro_dev1/asyn/lib/linux-x86_64 -Wl,-rpath,/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64 -Wl,-rpath,/data/bdee/devel/wavepro_dev1/epics-base/lib/linux-x86_64 -Wl,-rpath,/data/bdee/devel/wavepro_dev1/sscan/lib/linux-x86_64           -rdynamic -m64          streamApp_registerRecordDeviceDriver.o streamAppMain.o   -lstream -lasyn -lcalc -lsscan -ldbRecStd -ldbCore -lca -lCom -Wl,-Bdynamic  -lpthread   -lreadline -lm -lrt -ldl -lgcc
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_entry_editSseq_0_newCommand':
editSseq.c:(.text+0xbe): undefined reference to `seq_pvGetTmo'
editSseq.c:(.text+0xdc): undefined reference to `seq_pvGetTmo'
editSseq.c:(.text+0xfa): undefined reference to `seq_pvGetTmo'
editSseq.c:(.text+0x118): undefined reference to `seq_pvGetTmo'
editSseq.c:(.text+0x140): undefined reference to `seq_pvGetTmo'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o):editSseq.c:(.text+0x15e): more undefined references to `seq_pvGetTmo' follow
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_entry_editSseq_0_newCommand':
editSseq.c:(.text+0x197): undefined reference to `seq_pvPutTmo'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_entry_editSseq_0_newRecordName':
editSseq.c:(.text+0x347): undefined reference to `seq_pvPutTmo'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `editSseqRegistrar':
editSseq.c:(.text+0x3d5): undefined reference to `seqRegisterSequencerCommands'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_waitForCmnd':
editSseq.c:(.text+0x419): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0x439): undefined reference to `seq_pvPutTmo'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `reconcilePVs.isra.1':
editSseq.c:(.text+0x4af): undefined reference to `seq_pvPut'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_newRecordName':
editSseq.c:(.text+0x66b): undefined reference to `seq_pvAssign'
editSseq.c:(.text+0x682): undefined reference to `seq_pvGetTmo'
editSseq.c:(.text+0x71a): undefined reference to `seq_pvAssign'
editSseq.c:(.text+0x779): undefined reference to `seq_pvAssign'
editSseq.c:(.text+0x7cc): undefined reference to `seq_pvAssign'
editSseq.c:(.text+0x81f): undefined reference to `seq_pvAssign'
editSseq.c:(.text+0x88b): undefined reference to `seq_pvAssign'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o):editSseq.c:(.text+0x8ea): more undefined references to `seq_pvAssign' follow
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_entry_editSseq_0_waitForCmnd':
editSseq.c:(.text+0x989): undefined reference to `seq_efClear'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_init':
editSseq.c:(.text+0xa01): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0xa21): undefined reference to `seq_pvPutTmo'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_event_editSseq_0_waitForCmnd':
editSseq.c:(.text+0xa53): undefined reference to `seq_efTestAndClear'
editSseq.c:(.text+0xa81): undefined reference to `seq_efTestAndClear'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_newCommand':
editSseq.c:(.text+0xc55): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0xded): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0xe09): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0xed0): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0xef3): undefined reference to `seq_pvPutTmo'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o):editSseq.c:(.text+0xf79): more undefined references to `seq_pvPutTmo' follow
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_newCommand':
editSseq.c:(.text+0x1417): undefined reference to `seq_pvPut'
editSseq.c:(.text+0x1ae8): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0x1b04): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0x1b20): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0x1b3c): undefined reference to `seq_pvPutTmo'
editSseq.c:(.text+0x1b58): undefined reference to `seq_pvPutTmo'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o):editSseq.c:(.text+0x1b74): more undefined references to `seq_pvPutTmo' follow
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_newCommand':
editSseq.c:(.text+0x36a7): undefined reference to `seq_pvPut'
editSseq.c:(.text+0x36ef): undefined reference to `seq_pvPut'
editSseq.c:(.text+0x373f): undefined reference to `seq_pvPut'
editSseq.c:(.text+0x3787): undefined reference to `seq_pvPut'
editSseq.c:(.text+0x37cf): undefined reference to `seq_pvPut'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o):editSseq.c:(.text+0x3817): more undefined references to `seq_pvPut' follow
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_entry_editSseq_0_newCommand':
editSseq.c:(.text+0x1b8): undefined reference to `seq_pvPutTmo'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `editSseqRegistrar':
editSseq.c:(.text+0x3e5): undefined reference to `seqRegisterSequencerProgram'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_waitForCmnd':
editSseq.c:(.text+0x45a): undefined reference to `seq_pvPutTmo'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_init':
editSseq.c:(.text+0xa2f): undefined reference to `seq_efClear'
/data/bdee/devel/wavepro_dev1/calc/lib/linux-x86_64/libcalc.a(editSseq.o): In function `seqg_action_editSseq_0_newCommand':
editSseq.c:(.text+0xc86): undefined reference to `seq_pvPutTmo'
collect2: error: ld returned 1 exit status
make[2]: *** [streamApp] Error 1
make[2]: Leaving directory `/data/bdee/devel/wavepro_dev1/streamdevice/streamApp/O.linux-x86_64'
make[1]: *** [install.linux-x86_64] Error 2
make[1]: Leaving directory `/data/bdee/devel/wavepro_dev1/streamdevice/streamApp'
make: *** [streamApp.install] Error 2
```

This happens because calc in this case is compiled with SNCSEQ support, so when using this lib the modules should also link against libseq.
This error is similar to a recent pull request on asyn: https://github.com/epics-modules/asyn/pull/107 and only happens when compiling epics-base with `STATIC_BUILD=YES` option