### PR TITLE
Allow configuring of coloured console output

### DIFF
--- a/src/StreamBuffer.cc
+++ b/src/StreamBuffer.cc
@@ -341,7 +341,10 @@ StreamBuffer StreamBuffer::expand(ssize_t start, ssize_t length) const
     {
         c = buffer[i];
         if (c < 0x20 || c >= 0x7f)
-            result.print("\033[7m<%02x>\033[27m", c & 0xff);
+            result.print("%s<%02x>%s",
+                         ansiEscape(ANSI_REVERSE_VIDEO),
+                         c & 0xff,
+                         ansiEscape(ANSI_NOT_REVERSE_VIDEO));
         else
             result.append(c);
     }
@@ -354,18 +357,21 @@ dump() const
     StreamBuffer result;
     size_t i;
     result.print("%" P "d,%" P "d,%" P "d:", offs, len, cap);
-    if (offs) result.print("\033[47m");
+    if (offs) result.print(ansiEscape(ANSI_BG_WHITE));
     char c;
     for (i = 0; i < cap; i++)
     {
         c = buffer[i];
-        if (offs && i == offs) result.append("\033[0m");
+        if (offs && i == offs) result.append(ansiEscape(ANSI_RESET));
         if (c < 0x20 || c >= 0x7f)
-            result.print("\033[7m<%02x>\033[27m", c & 0xff);
+            result.print("%s<%02x>%s",
+                         ansiEscape(ANSI_REVERSE_VIDEO),
+                         c & 0xff,
+                         ansiEscape(ANSI_NOT_REVERSE_VIDEO));
         else
             result.append(c);
-        if (i == offs+len-1) result.append("\033[47m");
+        if (i == offs+len-1) result.append(ansiEscape(ANSI_BG_WHITE));
     }
-    result.append("\033[0m");
+    result.append(ansiEscape(ANSI_RESET));
     return result;
 }

--- a/src/StreamCore.cc
+++ b/src/StreamCore.cc
@@ -72,9 +72,9 @@ printCommands(StreamBuffer& buffer, const char* c)
                 buffer.append("    disconnect;\n");
                 break;
             default:
-                buffer.append("\033[31;1mGARBAGE: ");
+                buffer.append(ansiEscape(ANSI_RED_BOLD)).append("GARBAGE: ");
                 c = StreamProtocolParser::printString(buffer, c-1);
-                buffer.append("\033[0m\n");
+                buffer.append(ansiEscape(ANSI_RESET)).append("\n");
         }
     }
 }

--- a/src/StreamEpics.cc
+++ b/src/StreamEpics.cc
@@ -198,6 +198,7 @@ public:
 extern "C" { // needed for Windows
 epicsExportAddress(int, streamDebug);
 epicsExportAddress(int, streamError);
+epicsExportAddress(int, streamDebugColored);
 }
 
 // for subroutine record

--- a/src/StreamError.cc
+++ b/src/StreamError.cc
@@ -122,7 +122,7 @@ void StreamVError(int line, const char* file, const char* fmt, va_list args)
         va_end(args2);
     }
 #endif
-    fprintf(stderr, "%s%s", ansiEscape(ANSI_RED_BOLD), timestamp);
+    fprintf(stderr, "%s%s ", ansiEscape(ANSI_RED_BOLD), timestamp);
     if (file)
     {
         fprintf(stderr, "%s line %d: ", file, line);

--- a/src/StreamError.cc
+++ b/src/StreamError.cc
@@ -156,7 +156,6 @@ print(const char* fmt, ...)
 
 /**
  * Return an ANSI escape code if coloured debug output is enabled
- * If auto mode if selected (default), return code if a supported console type
  */
 const char* ansiEscape(AnsiMode mode)
 {

--- a/src/StreamError.cc
+++ b/src/StreamError.cc
@@ -28,7 +28,6 @@
 #include <string.h>
 #include <time.h>
 #include <stdio.h>
-#include <errlog.h>
 
 int streamDebug = 0;
 int streamError = 1;

--- a/src/StreamError.cc
+++ b/src/StreamError.cc
@@ -56,7 +56,8 @@ static bool win_console_init() {
     for(int i=0; i < sizeof(hCons) / sizeof(HANDLE); ++i)
     {
         DWORD dwMode = 0;
-        if (hCons[i] == INVALID_HANDLE_VALUE ||
+        if (hCons[i] == NULL ||
+            hCons[i] == INVALID_HANDLE_VALUE ||
             !GetConsoleMode(hCons[i], &dwMode))
         {
             return false;

--- a/src/StreamError.cc
+++ b/src/StreamError.cc
@@ -24,6 +24,8 @@
 #ifdef _WIN32
 #include <windows.h>
 #include <io.h>
+#else
+#include <unistd.h>
 #endif /* _WIN32 */
 #include <string.h>
 #include <time.h>

--- a/src/StreamError.h
+++ b/src/StreamError.h
@@ -32,6 +32,7 @@
 
 extern int streamDebug;
 extern int streamError;
+extern int streamDebugColored;
 extern void (*StreamPrintTimestampFunction)(char* buffer, size_t size);
 
 void StreamError(int line, const char* file, const char* fmt, ...)

--- a/src/StreamError.h
+++ b/src/StreamError.h
@@ -66,4 +66,11 @@ StreamDebugObject(const char* file, int line)
 #define error StreamError
 #define debug (!streamDebug)?0:StreamDebugObject(__FILE__,__LINE__).print
 
+/*
+ * ANSI escape sequences for terminal output
+ */
+enum AnsiMode { ANSI_REVERSE_VIDEO, ANSI_NOT_REVERSE_VIDEO, ANSI_BG_WHITE,
+                ANSI_RESET, ANSI_RED_BOLD };
+extern const char* ansiEscape(AnsiMode mode);
+
 #endif

--- a/src/makedbd.pl
+++ b/src/makedbd.pl
@@ -32,6 +32,7 @@ if (@ARGV[0] eq "-3.13") {
 } else {
     print "variable(streamDebug, int)\n";
     print "variable(streamError, int)\n";
+    print "variable(streamDebugColored, int)\n";
     print "registrar(streamRegistrar)\n";
     if ($asyn) { print "registrar(AsynDriverInterfaceRegistrar)\n"; }
 }


### PR DESCRIPTION
The STREAM_DEBUG_COLOR environment variable can be set to:
    yes  - always generate ANSI colour escape codes on debug/error output
    no   - use plain text output for debug/error
    auto - (default) output ANSI codes if terminal supports it