### PR TITLE
Introduce a logging dead time to avoid excessive logs

### DIFF
--- a/docs/setup.html
+++ b/docs/setup.html
@@ -399,11 +399,25 @@ Debug output can be redirected to a file with the command
 When called without a filename, debug output is directed back
 to the console.
 </p>
+<p>
+By default the debug/error output is set to be colored if the terminal allows
+it but this can be set to always colored or never colored by setting 
+<code>streamDebugColored</code> to 1 or 0 respectively.
+</p>
+<p>
+When a device is disconnected StreamDevice can produce many repeated timeout 
+messages. To reduce this logging you can set <code>streamErrorDeadTime</code>
+to an integer number of seconds. When this is set repeated timeout messages 
+will not be printed in the specified dead time after the last message. The 
+default dead time is 0, resulting in every message being printed.
+</p>
 
 <h3>Example (vxWorks):</h3>
 <pre>
 streamError=1
 streamDebug=1
+streamDebugColored=1
+streamErrorDeadTime=30
 streamSetLogfile("logfile.txt")
 </pre>
 
@@ -411,6 +425,8 @@ streamSetLogfile("logfile.txt")
 <pre>
 var streamError 1
 var streamDebug 1
+var streamDebugColored 1
+var streamErrorDeadTime 30
 streamSetLogfile("logfile.txt")
 </pre>
 

--- a/src/StreamCore.cc
+++ b/src/StreamCore.cc
@@ -489,6 +489,7 @@ finishProtocol(ProtocolResult status)
         switch (status)
         {
             case Success:
+                previousResult = Success;
                 handler = NULL;
                 break;
             case WriteTimeout:
@@ -991,8 +992,11 @@ readCallback(StreamIoStatus status,
                 evalIn();
                 return 0;
             }
-            error("%s: No reply within %ld ms to \"%s\"\n",
-                name(), replyTimeout, outputLine.expand()());
+            if (previousResult != ReplyTimeout) {
+                previousResult = ReplyTimeout;
+                error("%s: No reply within %ld ms to \"%s\"\n",
+                    name(), replyTimeout, outputLine.expand()());
+            }
             inputBuffer.clear();
             finishProtocol(ReplyTimeout);
             return 0;

--- a/src/StreamCore.cc
+++ b/src/StreamCore.cc
@@ -994,6 +994,12 @@ readCallback(StreamIoStatus status,
             }
             if (previousResult != ReplyTimeout) {
                 previousResult = ReplyTimeout;
+                time(&lastErrorTime);
+                error("%s: No reply within %ld ms to \"%s\"\n",
+                    name(), replyTimeout, outputLine.expand()());
+            }
+            else if (time(NULL) - lastErrorTime > 5) {
+                time(&lastErrorTime);
                 error("%s: No reply within %ld ms to \"%s\"\n",
                     name(), replyTimeout, outputLine.expand()());
             }

--- a/src/StreamCore.cc
+++ b/src/StreamCore.cc
@@ -27,6 +27,8 @@
 
 #define Z PRINTF_SIZE_T_PREFIX
 
+int DeadTime = 0;
+
 /// debug functions /////////////////////////////////////////////
 
 char* StreamCore::
@@ -1113,9 +1115,11 @@ readCallback(StreamIoStatus status,
         }
         else
         {
-            error("%s: Timeout after reading %" Z "d byte%s \"%s%s\"\n",
-                name(), end, end==1 ? "" : "s", end > 20 ? "..." : "",
-                inputBuffer.expand(-20)());
+            if (checkShouldPrint(ReadTimeout)) {
+                error("%s: Timeout after reading %" Z "d byte%s \"%s%s\"\n",
+                    name(), end, end==1 ? "" : "s", end > 20 ? "..." : "",
+                    inputBuffer.expand(-20)());
+            }
         }
     }
 
@@ -1845,11 +1849,11 @@ bool  StreamCore::checkShouldPrint(ProtocolResult newErrorType)
         time(&lastErrorTime);
         return true;
     }
-    else if (time(NULL) - lastErrorTime > 5) {
+    else if (time(NULL) - lastErrorTime > DeadTime) {
         time(&lastErrorTime);
         if (numberOfErrors != 0) {
             error("%s: %i additional errors of the following type seen in the last %i seconds\n",
-                name(), numberOfErrors, 5);
+                name(), numberOfErrors, DeadTime);
         }
         numberOfErrors = 0;
         return true;

--- a/src/StreamCore.cc
+++ b/src/StreamCore.cc
@@ -27,7 +27,7 @@
 
 #define Z PRINTF_SIZE_T_PREFIX
 
-int DeadTime = 0;
+int streamErrorDeadTime = 0;
 
 /// debug functions /////////////////////////////////////////////
 
@@ -1849,11 +1849,11 @@ bool  StreamCore::checkShouldPrint(ProtocolResult newErrorType)
         time(&lastErrorTime);
         return true;
     }
-    else if (time(NULL) - lastErrorTime > DeadTime) {
+    else if (time(NULL) - lastErrorTime > streamErrorDeadTime) {
         time(&lastErrorTime);
         if (numberOfErrors != 0) {
             error("%s: %i additional errors of the following type seen in the last %i seconds\n",
-                name(), numberOfErrors, DeadTime);
+                name(), numberOfErrors, streamErrorDeadTime);
         }
         numberOfErrors = 0;
         return true;

--- a/src/StreamCore.cc
+++ b/src/StreamCore.cc
@@ -490,6 +490,7 @@ finishProtocol(ProtocolResult status)
         {
             case Success:
                 previousResult = Success;
+                numberOfErrors = 0;
                 handler = NULL;
                 break;
             case WriteTimeout:
@@ -992,14 +993,7 @@ readCallback(StreamIoStatus status,
                 evalIn();
                 return 0;
             }
-            if (previousResult != ReplyTimeout) {
-                previousResult = ReplyTimeout;
-                time(&lastErrorTime);
-                error("%s: No reply within %ld ms to \"%s\"\n",
-                    name(), replyTimeout, outputLine.expand()());
-            }
-            else if (time(NULL) - lastErrorTime > 5) {
-                time(&lastErrorTime);
+            if (checkShouldPrint(ReplyTimeout)) {
                 error("%s: No reply within %ld ms to \"%s\"\n",
                     name(), replyTimeout, outputLine.expand()());
             }
@@ -1831,6 +1825,39 @@ license(void)
         "\n"
         "You should have received a copy of the GNU Lesser General Public License\n"
         "along with StreamDevice. If not, see https://www.gnu.org/licenses/.\n";
+}
+
+/**
+ * \brief Checks whether an error message should be printed based on the new error type.
+ *
+ * Will check based on the error type and the time since last error of the same type
+ * whether to print the new error. Also has a number of side effects such as counting 
+ * up errors of each type and resetting the time since last error.
+ *
+ * \param[in] newErrorType the type of the new error
+ * \return true if the error should be preinted, else false
+ */
+bool  StreamCore::checkShouldPrint(ProtocolResult newErrorType) 
+{
+    if (previousResult != newErrorType) {
+        previousResult = newErrorType;
+        numberOfErrors = 0;
+        time(&lastErrorTime);
+        return true;
+    }
+    else if (time(NULL) - lastErrorTime > 5) {
+        time(&lastErrorTime);
+        if (numberOfErrors != 0) {
+            error("%s: %i additional errors of the following type seen in the last %i seconds\n",
+                name(), numberOfErrors, 5);
+        }
+        numberOfErrors = 0;
+        return true;
+    }
+    else {
+        numberOfErrors++;
+        return false;
+    }
 }
 
 #include "streamReferences"

--- a/src/StreamCore.h
+++ b/src/StreamCore.h
@@ -74,7 +74,6 @@ void acceptEvent(unsigned short mask, unsigned short timeout)
 
 #include "MacroMagic.h"
 
-
 // Flags: 0x00FFFFFF reserved for StreamCore
 const unsigned long None             = 0x0000;
 const unsigned long IgnoreExtraInput = 0x0001;
@@ -170,6 +169,7 @@ protected:
     StreamBuffer inputBuffer;
     StreamBuffer inputLine;
     size_t consumedInput;
+    ProtocolResult previousResult = Success;
     ProtocolResult runningHandler;
     StreamBuffer fieldAddress;
 

--- a/src/StreamCore.h
+++ b/src/StreamCore.h
@@ -73,6 +73,7 @@ void acceptEvent(unsigned short mask, unsigned short timeout)
 ***************************************/
 
 #include "MacroMagic.h"
+#include "time.h"
 
 // Flags: 0x00FFFFFF reserved for StreamCore
 const unsigned long None             = 0x0000;
@@ -169,9 +170,11 @@ protected:
     StreamBuffer inputBuffer;
     StreamBuffer inputLine;
     size_t consumedInput;
-    ProtocolResult previousResult = Success;
     ProtocolResult runningHandler;
     StreamBuffer fieldAddress;
+
+    ProtocolResult previousResult = Success;
+    time_t lastErrorTime;
 
     StreamIoStatus lastInputStatus;
     bool unparsedInput;

--- a/src/StreamCore.h
+++ b/src/StreamCore.h
@@ -173,8 +173,10 @@ protected:
     ProtocolResult runningHandler;
     StreamBuffer fieldAddress;
 
+    // Keep track of errors to reduce logging frequencies
     ProtocolResult previousResult = Success;
     time_t lastErrorTime;
+    int numberOfErrors = 0;
 
     StreamIoStatus lastInputStatus;
     bool unparsedInput;
@@ -233,6 +235,7 @@ public:
 
 private:
     char* printCommands(StreamBuffer& buffer, const char* c);
+    bool  checkShouldPrint(ProtocolResult newErrorType);
 };
 
 #endif

--- a/src/StreamCore.h
+++ b/src/StreamCore.h
@@ -95,6 +95,9 @@ const unsigned long ClearOnStart     = InitRun|AsyncMode|GotValue|Aborted|
                                        BusOwner|Separator|ScanTried|
                                        AcceptInput|AcceptEvent|BusPending;
 
+// The amount of time to wait before printing duplicated messages
+extern int DeadTime;
+
 struct StreamFormat;
 
 class StreamCore :

--- a/src/StreamCore.h
+++ b/src/StreamCore.h
@@ -96,7 +96,7 @@ const unsigned long ClearOnStart     = InitRun|AsyncMode|GotValue|Aborted|
                                        AcceptInput|AcceptEvent|BusPending;
 
 // The amount of time to wait before printing duplicated messages
-extern int DeadTime;
+extern int streamErrorDeadTime;
 
 struct StreamFormat;
 

--- a/src/StreamEpics.cc
+++ b/src/StreamEpics.cc
@@ -199,6 +199,7 @@ extern "C" { // needed for Windows
 epicsExportAddress(int, streamDebug);
 epicsExportAddress(int, streamError);
 epicsExportAddress(int, streamDebugColored);
+epicsExportAddress(int, streamErrorDeadTime);
 }
 
 // for subroutine record
@@ -261,12 +262,6 @@ long streamSetLogfile(const char* filename)
     return OK;
 }
 
-long streamMessageDeadTime(int newDeadTime)
-{
-    DeadTime = newDeadTime;
-    return OK;
-}
-
 #ifndef EPICS_3_13
 static const iocshArg streamReloadArg0 =
     { "recordname", iocshArgString };
@@ -304,26 +299,11 @@ void streamSetLogfileFunc (const iocshArgBuf *args)
     streamSetLogfile(args[0].sval);
 }
 
-// Setting a dead time for messages at the IOC Console will cause repeated messages to only be periodically logged.
-static const iocshArg streamMessageDeadTimeArg0 =
-    { "dead time (s)", iocshArgInt };
-static const iocshArg * const streamMessageDeadTimeArgs[] =
-    { &streamMessageDeadTimeArg0 };
-static const iocshFuncDef messageDeadTimeDef =
-    { "streamMessageDeadTime", 1, streamMessageDeadTimeArgs };
-
-extern "C" void messageDeadTimeFunc(const iocshArgBuf *args)
-{
-    streamMessageDeadTime(args[0].ival);
-}
-
-
 static void streamRegistrar ()
 {
     iocshRegister(&streamReloadDef, streamReloadFunc);
     iocshRegister(&streamReportRecordDef, streamReportRecordFunc);
     iocshRegister(&streamSetLogfileDef, streamSetLogfileFunc);
-    iocshRegister(&messageDeadTimeDef, messageDeadTimeFunc);
     // make streamReload available for subroutine records
     registryFunctionAdd("streamReload",
         (REGISTRYFUNCTION)streamReloadSub);

--- a/src/StreamEpics.cc
+++ b/src/StreamEpics.cc
@@ -261,6 +261,12 @@ long streamSetLogfile(const char* filename)
     return OK;
 }
 
+long streamMessageDeadTime(int newDeadTime)
+{
+    DeadTime = newDeadTime;
+    return OK;
+}
+
 #ifndef EPICS_3_13
 static const iocshArg streamReloadArg0 =
     { "recordname", iocshArgString };
@@ -298,11 +304,26 @@ void streamSetLogfileFunc (const iocshArgBuf *args)
     streamSetLogfile(args[0].sval);
 }
 
+// Setting a dead time for messages at the IOC Console will cause repeated messages to only be periodically logged.
+static const iocshArg streamMessageDeadTimeArg0 =
+    { "dead time (s)", iocshArgInt };
+static const iocshArg * const streamMessageDeadTimeArgs[] =
+    { &streamMessageDeadTimeArg0 };
+static const iocshFuncDef messageDeadTimeDef =
+    { "streamMessageDeadTime", 1, streamMessageDeadTimeArgs };
+
+extern "C" void messageDeadTimeFunc(const iocshArgBuf *args)
+{
+    streamMessageDeadTime(args[0].ival);
+}
+
+
 static void streamRegistrar ()
 {
     iocshRegister(&streamReloadDef, streamReloadFunc);
     iocshRegister(&streamReportRecordDef, streamReportRecordFunc);
     iocshRegister(&streamSetLogfileDef, streamSetLogfileFunc);
+    iocshRegister(&messageDeadTimeDef, messageDeadTimeFunc);
     // make streamReload available for subroutine records
     registryFunctionAdd("streamReload",
         (REGISTRYFUNCTION)streamReloadSub);

--- a/src/makedbd.pl
+++ b/src/makedbd.pl
@@ -33,6 +33,7 @@ if (@ARGV[0] eq "-3.13") {
     print "variable(streamDebug, int)\n";
     print "variable(streamError, int)\n";
     print "variable(streamDebugColored, int)\n";
+    print "variable(streamErrorDeadTime, int)\n";
     print "registrar(streamRegistrar)\n";
     if ($asyn) { print "registrar(AsynDriverInterfaceRegistrar)\n"; }
 }


### PR DESCRIPTION
See https://github.com/paulscherrerinstitute/StreamDevice/issues/67

See docs for how to use, I also documented https://github.com/paulscherrerinstitute/StreamDevice/pull/64 while I was there.

Notes:
* I've only done this for the reply timeout (which we get from most disconnected equipment) and the timeout after getting some characters (which we've seen for disconnected equipment with interference on the line). It should be written in such a way to be extensible.
* I've reused `ProtocolResult` for the error type but open to a specific enum