### PR TITLE
LRC checksum

### DIFF
--- a/docs/formats.html
+++ b/docs/formats.html
@@ -589,6 +589,11 @@ In input, the next byte or bytes must match the checksum.
    href="http://www.ietf.org/rfc/rfc1950.txt">RFC 1950</a>.</dd>
  <dt><code>%&lt;hexsum8&gt;</code></dt>
   <dd>One byte. The sum of all hex digits. (Other characters are ignored.)</dd>
+ <dt><code>%&lt;lrc&gt;</code></dt>
+  <dd>One byte. The Longitudinal Redundancy Check according to <a target="ex"
+   href="https://en.wikipedia.org/wiki/Longitudinal_redundancy_check">Wikipedia</a>.</dd>
+ <dt><code>%&lt;hexlrc&gt;</code></dt>
+  <dd>One byte. The LRC for the hex digits. (Other characters are ignored.)</dd>
 </dl>
 
 <a name="regex"></a>

--- a/streamApp/checksums.proto
+++ b/streamApp/checksums.proto
@@ -54,4 +54,6 @@ write {
     out "%s  hexsum8   %0.12<hexsum8>";
     out "%s  cpi       %0.12<cpi>";
     out "%s  leybold   %0.12<leybold>";
+    out "%s  lrc       %0.12<lrc>";
+    out "%s  hexlrc    %0.12<hexlrc>";
 }


### PR DESCRIPTION
I've created two LRC checksum functions:

- lrc: uses the ASCII code of each character (uses the value 0x30 for the character '0', 0x31 for '1', etc) which I understand is how most checksums are implemented.
- hexlrc: group hexadecimal characters in pairs and interpret the pair as a hexadecimal number. Examples: '12' gets converted to 0x12 and 'A5' to 0xA5.

Thanks @ljsSally for the piece of code.