### PR TITLE
Fix cplusplus linkage error with extern C

### DIFF
--- a/src/ChecksumConverter.cc
+++ b/src/ChecksumConverter.cc
@@ -52,11 +52,15 @@
 #if defined(vxWorks) || defined(__rtems__)
 // These systems have no strncasecmp at the moment
 // But avoid compiler errors in case strncasecmp exists in future versions
-static int mystrncasecmp(const char *s1, const char *s2, size_t n)
-{
-    int r=0;
-    while (n && (r = toupper(*s1)-toupper(*s2)) == 0) { n--; s1++; s2++; };
-    return r;
+extern "C" {
+
+    static int mystrncasecmp(const char *s1, const char *s2, size_t n)
+    {
+        int r=0;
+        while (n && (r = toupper(*s1)-toupper(*s2)) == 0) { n--; s1++; s2++; };
+        return r;
+    }
+
 }
 #define strncasecmp mystrncasecmp
 #endif


### PR DESCRIPTION
I added some details in #83.

I've never seen this kind of error. This post gave some insight, esp the static declaration inside an extern scope seemed suspicious. It looks like a valid fix. Maybe you have a better or simpler fix.

https://stackoverflow.com/questions/1041866/what-is-the-effect-of-extern-c-in-c