### PR TITLE
Quiet warning with -Wformat-security

### DIFF
--- a/src/StreamBuffer.cc
+++ b/src/StreamBuffer.cc
@@ -358,7 +358,7 @@ dump() const
     StreamBuffer result;
     size_t i;
     result.print("%" P "d,%" P "d,%" P "d:", offs, len, cap);
-    if (offs) result.print(ansiEscape(ANSI_BG_WHITE));
+    if (offs) result.print("%s", ansiEscape(ANSI_BG_WHITE));
     char c;
     for (i = 0; i < cap; i++)
     {


### PR DESCRIPTION
Best practice is to only use constant format strings, which `ansiEscape()` almost is.

This is an issue for me as I try to follow the Debian [hardening](https://wiki.debian.org/Hardening) recommended CFLAGS.

```make
OP_SYS_CFLAGS += -fstack-protector-strong -Wformat -Werror=format-security
OP_SYS_CXXFLAGS += -fstack-protector-strong -Wformat -Werror=format-security
OP_SYS_CPPFLAGS += -Wdate-time -D_FORTIFY_SOURCE=2
```
