### PR TITLE
Removed hardcode CHECK_RELEASE in configure/Makefile

### DIFF
--- a/configure/Makefile
+++ b/configure/Makefile
@@ -4,10 +4,6 @@ TOP=..
 
 include $(TOP)/configure/CONFIG
 
-# Set the following to NO to disable consistency checking of
-# the support applications defined in $(TOP)/configure/RELEASE
-CHECK_RELEASE = YES
-
 TARGETS = $(CONFIG_TARGETS)
 CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
 


### PR DESCRIPTION
Hi @dirk-zimoch 

How are you doing? I am glad the StreamDevice finally has the standard EPICS building system. 

And please check this change; I removed the hard-coded `CHECK_RELEASE` in `configure/Makefile`. This hard-code makes a global CHECK_RELEASE defined in `CONFIG_SITE` useless. 

Your CONFIG_SITE already has its definition, so it is unnecessary to be there.

Best,
@jeonghanlee 