### PR TITLE
ensure \0 after moving data to start of the buffer

### DIFF
--- a/src/StreamBuffer.cc
+++ b/src/StreamBuffer.cc
@@ -327,37 +327,37 @@ replace(ssize_t remstart, ssize_t remlen, const void* ins, ssize_t inslen)
     }
     else
     {
-        hexdump(buffer, cap + 16);
+        // hexdump(buffer, cap + 16);
         if (newlen+offs<=cap)
         {
-            printf("%s:%d case 1 %ld <= %ld\n", __func__, __LINE__, newlen+offs, cap);
+            // printf("%s:%d case 1 %ld <= %ld\n", __func__, __LINE__, newlen+offs, cap);
             // move to start of buffer
             memmove(buffer+offs+remstart+inslen, buffer+offs+remend, len-remend);
             memcpy(buffer+offs+remstart, ins, inslen);
             if (newlen<len) {
-                printf("%s:%d case 1 memset from %ld size %ld\n", __func__, __LINE__, offs+newlen, len-newlen);
+                // printf("%s:%d case 1 memset from %ld size %ld\n", __func__, __LINE__, offs+newlen, len-newlen);
                 memset(buffer+offs+newlen, 0, len-newlen);
             }
         }
         else
         {
-            printf("%s:%d case 2 %ld > %ld\n", __func__, __LINE__, newlen+offs, cap);
-            printf("%s:%d case 2 remstart %ld, offs %ld, remend %ld, len-remend %ld, newlen %ld\n", __func__, __LINE__, remstart, offs, remend, len-remend, newlen);
+            // printf("%s:%d case 2 %ld > %ld\n", __func__, __LINE__, newlen+offs, cap);
+            // printf("%s:%d case 2 remstart %ld, offs %ld, remend %ld, len-remend %ld, newlen %ld\n", __func__, __LINE__, remstart, offs, remend, len-remend, newlen);
             memmove(buffer,buffer+offs,remstart);
             memmove(buffer+remstart+inslen, buffer+offs+remend, len-remend);
             memcpy(buffer+remstart, ins, inslen);
             if (newlen<len) {
-                printf("%s:%d case 2 A memset from %ld size %ld\n", __func__, __LINE__, newlen, len-newlen);
+                // printf("%s:%d case 2 A memset from %ld size %ld\n", __func__, __LINE__, newlen, len-newlen);
                 memset(buffer+newlen, 0, len-newlen);
             } else {
                 // HK: this is new!
                 // Seems to solve the isseu when newlen > len; will put \0 right after the string
-                printf("%s:%d case 2 B memset from %ld size %ld\n", __func__, __LINE__, newlen, cap-newlen);
+                // printf("%s:%d case 2 B memset from %ld size %ld\n", __func__, __LINE__, newlen, cap-newlen);
                 memset(buffer+newlen, 0, cap-newlen);
             }
             offs = 0;
         }
-        hexdump(buffer, cap + 16);
+        // hexdump(buffer, cap + 16);
     }
     len = newlen;
     return *this;

--- a/src/StreamBuffer.cc
+++ b/src/StreamBuffer.cc
@@ -135,6 +135,8 @@ init(const void* s, ssize_t minsize)
     offs = 0;
     buffer = local;
     cap = sizeof(local);
+    // HK: used to terminate the local buffer if string is 64 bytes long
+    term = 0;
     if (minsize < 0) minsize = 0;
     if ((size_t)minsize >= cap)
     {

--- a/src/StreamBuffer.h
+++ b/src/StreamBuffer.h
@@ -38,6 +38,8 @@ typedef ptrdiff_t ssize_t;
 class StreamBuffer
 {
     char local[64];
+    // HK: used to terminate the local buffer if string is 64 bytes long
+    char term;
     size_t len;
     size_t cap;
     size_t offs;

--- a/src/StreamCore.cc
+++ b/src/StreamCore.cc
@@ -1553,13 +1553,24 @@ scanValue(const StreamFormat& fmt, char* value, size_t& size)
             value[0] = 0;
             consumed = 0;
         }
-        else return -1;
+        else {
+            printf("%s:%d returning %ld\n", __func__, __LINE__, consumed);
+            return -1;
+        }
     }
     debug("StreamCore::scanValue(%s, format=%%%c, char*, size=%" Z "d) input=\"%s\" value=\"%s\"\n",
         name(), fmt.conv, size, inputLine.expand(consumedInput)(),
         StreamBuffer(value, size).expand()());
-    if (fmt.flags & fix_width_flag && consumed != (ssize_t)fmt.width) return -1;
-    if ((size_t)consumed > inputLine.length()-consumedInput) return -1;
+    if (fmt.flags & fix_width_flag && consumed != (ssize_t)fmt.width) {
+        printf("%s:%d returning %ld\n", __func__, __LINE__, consumed);
+        return -1;
+    }
+    if ((size_t)consumed > inputLine.length()-consumedInput) {
+        // HK: hitting this case when 'Input "A03" does not match format "%s"'
+        printf("%s:%d returning %ld\n", __func__, __LINE__, consumed);
+        return -1;
+    }
+
     flags |= GotValue;
     return consumed;
 }


### PR DESCRIPTION
***DO NOT MERGE***

This is some debugging done for #97 that might help ..

These ugly code hacks solve the case where `newlen` is larger than `len` and the buffer data is moved to the start of the buffer (L350 - L355 in the patch) and there is no \0 seen afterwards. The IOC would always report `%s` mismatch. In other words, I do not see the mismatch on `%s` occurring anymore as a consequence of executing this part of the code.

But ..

In the attached file you can find two cases of failure and one success case ; in all cases the `newlen+offs` == `cap` and therefore `memset()` is not called.
In the hexdump output one can see 16 more bytes that do not belong to the buffer (cap = 64). I thought byte 40 would be `\0` in the successful case ; but that is not the case. Also looking at the lines with `buffer after:` the next character that causes the `%s` to fail is not the one at hexdump offset 40. This makes me think that there is another issue elsewhere, outside the `StreamBuffer::replace()`. 

[stream-errors.txt](https://github.com/paulscherrerinstitute/StreamDevice/files/14525959/stream-errors.txt)

Of course I might be totally wrong 'cause I do not know any parts of the source code. I'll be looking into it later on .. unless you beat me to it ;)


EDIT:
Ups, just noticed that the text file was not made with master branch of the streamdevice code so the line numbers in there are off. I did run the master branch code, too, and saw the issues I was seeing with the "older" code I was running earlier. Will run all new debug on the master branch code from now on